### PR TITLE
Use parameter value for login URL in exec_anon.xml

### DIFF
--- a/lib/exec_anon.xml
+++ b/lib/exec_anon.xml
@@ -107,7 +107,7 @@
 		<attribute name="sessionId" description="Session Id property."/>
 		<sequential>
 			<!-- Obtain Session Id via Login SOAP service -->
-		    <http url="https://login.salesforce.com/services/Soap/c/30.0" method="POST" failonunexpected="false" entityProperty="loginResponse" statusProperty="loginResponseStatus">
+		    <http url="https://${host}/services/Soap/c/30.0" method="POST" failonunexpected="false" entityProperty="loginResponse" statusProperty="loginResponseStatus">
 		    	<headers>
 		    		<header name="Content-Type" value="text/xml"/>
 		    		<header name="SOAPAction" value="login"/>


### PR DESCRIPTION
Fixes issue where Execute Anonymous against a sandbox fails due to URL being hard-coded to login.salesforce.com.