### PR TITLE
undeploy: halt scheduled jobs before modifying apex classes

### DIFF
--- a/lib/undeploy.xml
+++ b/lib/undeploy.xml
@@ -36,7 +36,7 @@
 
  <antcall target="parkUsers"/>
  <antcall target="deleteEmailTemplates"/>
-
+ <antcall target="haltScheduledApex"/>
  <antcall target="generatePackageAll"/>
  <sf:retrieve username="${sf.username}" password="${sf.password}" serverurl="${sf.server}" retrieveTarget="${stage.dir}" unpackaged="${stage.dir}/package.xml" maxPoll="2000" pollWaitMillis="5000"/>
 
@@ -91,6 +91,17 @@ update uL;]]>
   </antcall>
 </target>
 
+<target name="haltScheduledApex">
+  <property name="halt.scheduledapex"><![CDATA[
+List<CronTrigger> crons = [SELECT Id FROM CronTrigger WHERE State IN ('WAITING', 'ACQUIRED', 'EXECUTING', 'PAUSED', 'BLOCKED', 'PAUSED_BLOCKED')];
+for(CronTrigger cron : crons) {
+    System.abortJob(cron.Id);
+}]]>
+  </property>
+  <antcall target="ExecAnon">
+    <param name="what" value="${halt.scheduledapex}"/>
+  </antcall>
+</target>
 
 <target name="generateEmptyPackage">
 <echo file="${stage.dir}/deploy/package.xml"><![CDATA[<?xml version="1.0" encoding="UTF-8"?>


### PR DESCRIPTION
Undeploy will fail if any apex jobs are scheduled. Using the ExecAnon target, select and System.abortJob() them.